### PR TITLE
Fixed issue with multiple arrays with same name

### DIFF
--- a/src/WSDL/Parser/WrapperParser.php
+++ b/src/WSDL/Parser/WrapperParser.php
@@ -41,6 +41,12 @@ class WrapperParser
      */
     private $_complexTypes;
 
+    /**
+     * @desc Count of arrays in document
+     * @var array
+     */
+    static private $arrayCnt = [];
+
     public function __construct($wrapperClass)
     {
         $this->_wrapperClass = new ReflectionClass($wrapperClass);
@@ -85,7 +91,7 @@ class WrapperParser
                 break;
         }
     }
-    
+
     private function _createWrapperObject($type, $name, $docComment)
     {
         $wrapper = $this->wrapper($type, $docComment);
@@ -106,14 +112,17 @@ class WrapperParser
             $complex = $this->getComplexTypes();
             $object = new Object($type, $name, $complex);
         }
-        return new Arrays($type, $name, $object);
+        if (!isset(self::$arrayCnt[$name])) {
+            self::$arrayCnt[$name] = 0;
+        }
+        return new Arrays($type, $name, $object, self::$arrayCnt[$name]++);
     }
 
     public function getComplexTypes()
     {
         return $this->_complexTypes;
     }
-    
+
     public function wrapper(&$type, $docComment)
     {
         if (!$this->isComplex($type)) {

--- a/src/WSDL/Types/Arrays.php
+++ b/src/WSDL/Types/Arrays.php
@@ -35,12 +35,14 @@ class Arrays implements Type
     private $_type;
     private $_name;
     private $_complexType;
+    private $_counter;
 
-    public function __construct($type, $name, $complexType)
+    public function __construct($type, $name, $complexType, $counter = 0)
     {
         $this->_type = $type;
         $this->_name = $name;
         $this->_complexType = $complexType;
+        $this->_counter = $counter;
     }
 
     public function getType()
@@ -59,5 +61,10 @@ class Arrays implements Type
     public function getComplexType()
     {
         return $this->_complexType;
+    }
+
+    public function getCounter()
+    {
+        return $this->_counter;
     }
 }

--- a/src/WSDL/XML/Styles/Style.php
+++ b/src/WSDL/XML/Styles/Style.php
@@ -67,7 +67,7 @@ abstract class Style
             $value = TypeHelper::getXsdType($parameter->getType());
         } elseif (TypeHelper::isArray($parameter)) {
             $type = 'type';
-            $value = 'ns:' . 'ArrayOf' . ucfirst($parameter->getName());
+            $value = 'ns:' . 'ArrayOf' . ucfirst($parameter->getName()) . ($parameter->getCounter() ? $parameter->getCounter() : '');
         } elseif (TypeHelper::isObject($parameter)) {
             $type = 'element';
             $value = 'ns:' . $this->_getObjectName($parameter);
@@ -108,7 +108,7 @@ abstract class Style
 
         $typesComplex = new TypesComplex();
         $typesComplex
-            ->setName('ArrayOf' . ucfirst($parameter->getName()))
+            ->setName('ArrayOf' . ucfirst($parameter->getName()) . ($parameter->getCounter() ? $parameter->getCounter() : ''))
             ->setArrayType($type . $this->_getObjectName($parameter) . '[]')
             ->setArrayTypeName(Inflector::singularize($parameter->getName()));
 


### PR DESCRIPTION
- When more arrays shares same name, but different type, it referenced to wrong type (e.g. object)
